### PR TITLE
Handle all-in raises reopening betting

### DIFF
--- a/src/main/scala/poker/engine/BettingRound.scala
+++ b/src/main/scala/poker/engine/BettingRound.scala
@@ -45,7 +45,9 @@ final case class BettingRound(
       case Action.Fold => sanitizedPending - playerId
       case Action.Check => sanitizedPending - playerId
       case Action.Call => sanitizedPending - playerId
-      case Action.AllIn => sanitizedPending - playerId
+      case Action.AllIn =>
+        if (updated.bet > currentBet) activeIds - playerId
+        else sanitizedPending - playerId
       case Action.Bet(_) => activeIds - playerId
       case Action.Raise(_) => activeIds - playerId
     }

--- a/src/test/scala/poker/engine/BettingRoundSpec.scala
+++ b/src/test/scala/poker/engine/BettingRoundSpec.scala
@@ -1,0 +1,28 @@
+package poker.engine
+
+import org.scalatest.funsuite.AnyFunSuite
+import poker.model.{Action, Player, PlayerStatus}
+
+final class BettingRoundSpec extends AnyFunSuite {
+  test("all-in raise reopens action for remaining players") {
+    val player1 = Player(1, seat = 0, name = "P1", isHuman = false, stack = 100, bet = 50, status = PlayerStatus.Active)
+    val player2 = Player(2, seat = 1, name = "P2", isHuman = false, stack = 120, bet = 50, status = PlayerStatus.Active)
+    val player3Before = Player(3, seat = 2, name = "P3", isHuman = false, stack = 60, bet = 50, status = PlayerStatus.Active)
+    val player3After = player3Before.withBet(player3Before.bet + player3Before.stack)
+
+    val playersAfter = Vector(player1, player2, player3After)
+    val round = BettingRound(
+      currentBet = 50,
+      minRaise = 10,
+      lastAggressor = Some(2),
+      pending = Set(3),
+      actionOrder = Vector(1, 2, 3),
+      pointer = 0
+    )
+
+    val updatedRound = round.onAction(player3Before, Action.AllIn, player3After, playersAfter)
+
+    assert(updatedRound.currentBet == player3After.bet)
+    assert(updatedRound.pending == Set(1, 2))
+  }
+}


### PR DESCRIPTION
## Summary
- ensure all-in actions that exceed the current bet reopen pending action for other active players
- add a betting round unit test covering a third player moving all-in above the standing bet

## Testing
- `sbt test` *(fails: sbt command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdca29930832598193542685dbb0d