### PR TITLE
Refresh bot policy after opponent model updates

### DIFF
--- a/src/main/scala/poker/ai/Bot.scala
+++ b/src/main/scala/poker/ai/Bot.scala
@@ -1,20 +1,40 @@
 package poker.ai
 
 import poker.engine.GameState
-import poker.model.{Action, Config, ShowdownResult}
+import poker.model.{Action, Config, Player, ShowdownResult}
 
 import scala.util.Random
 
-final class Bot(val playerId: Int, profile: AIProfile, config: Config) {
-  private val policy = new AIPolicy(profile)
+final class Bot(
+  val playerId: Int,
+  profile: AIProfile,
+  config: Config,
+  evaluateHand: (GameState, Player, Int, Random) => HandStrength = HandStrength.evaluate
+) {
   private var opponentModel: OpponentModel = OpponentModel(profile.riskTolerance, profile.bluffFrequency, profile.aggression, profile.callStation)
+  private var policy: AIPolicy = buildPolicy()
   private val rng = config.rngSeed.map(seed => new Random(seed + playerId)).getOrElse(new Random())
 
+  private def buildPolicy(): AIPolicy =
+    new AIPolicy(
+      AIProfile(
+        riskTolerance = opponentModel.riskTolerance,
+        bluffFrequency = opponentModel.bluffFrequency,
+        aggression = opponentModel.aggression,
+        callStation = opponentModel.callStation
+      )
+    )
+
+  private def refreshPolicy(): Unit = {
+    policy = buildPolicy()
+  }
+
   def decide(state: GameState): Action = {
+    refreshPolicy()
     val player = state.playerById(playerId).getOrElse(throw new IllegalStateException(s"Player $playerId not found"))
     val round = state.bettingRound.getOrElse(throw new IllegalStateException("No betting round active"))
     val callAmount = math.max(0, round.currentBet - player.bet)
-    val strength = HandStrength.evaluate(state, player, config.mcIterations, rng)
+    val strength = evaluateHand(state, player, config.mcIterations, rng)
     val ctx = DecisionContext(
       strength = strength,
       callAmount = callAmount,
@@ -30,5 +50,6 @@ final class Bot(val playerId: Int, profile: AIProfile, config: Config) {
 
   def observeShowdown(result: Option[ShowdownResult]): Unit = {
     opponentModel = opponentModel.adjustOnOutcome(result.exists(_.playerId == playerId))
+    refreshPolicy()
   }
 }

--- a/src/test/scala/poker/BotSpec.scala
+++ b/src/test/scala/poker/BotSpec.scala
@@ -1,0 +1,48 @@
+package poker
+
+import org.scalatest.funsuite.AnyFunSuite
+import poker.ai.{AIProfile, Bot, HandStrength}
+import poker.engine.{BettingRound, Deck, GameState, HandCategory, HandRank}
+import poker.model.{Action, Config, Player, PlayerStatus, ShowdownResult, Street}
+
+import scala.util.Random
+
+final class BotSpec extends AnyFunSuite {
+  private val profile = AIProfile(riskTolerance = 0.9, bluffFrequency = 0.08, aggression = 0.3, callStation = 0.2)
+  private val config = Config(rngSeed = Some(123L), mcIterations = 100)
+
+  private val fixedStrength = HandStrength(0.6, HandRank(HandCategory.Pair, Vector(12, 10, 8, 6, 4)))
+  private val evaluator = (_: GameState, _: Player, _: Int, _: Random) => fixedStrength
+
+  private def baseState: GameState = {
+    val hero = Player(id = 1, seat = 0, name = "Bot", isHuman = false, stack = 50, bet = 0, status = PlayerStatus.Active)
+    val villain = Player(id = 2, seat = 1, name = "Villain", isHuman = false, stack = 200, bet = 50, status = PlayerStatus.Folded)
+    val pot = poker.engine.PotManager(Map(2 -> 10))
+    val round = BettingRound(currentBet = 50, minRaise = 10, lastAggressor = Some(2), pending = Set(1), actionOrder = Vector(1), pointer = 0)
+
+    GameState(
+      config = config,
+      handId = 1L,
+      players = Vector(hero, villain),
+      buttonIndex = 0,
+      deck = Deck(config.rngSeed),
+      board = Vector.empty,
+      street = Street.Turn,
+      potManager = pot,
+      bettingRound = Some(round)
+    )
+  }
+
+  test("bot regenerates policy after opponent model adjustment") {
+    val bot = new Bot(playerId = 1, profile = profile, config = config, evaluateHand = evaluator)
+    val state = baseState
+
+    assert(bot.decide(state) == Action.AllIn)
+
+    val loss = ShowdownResult(playerId = 2, handRank = HandRank(HandCategory.HighCard, Vector(14, 5, 4, 3, 2)), share = 0, cards = Vector.empty)
+    (0 until 50).foreach(_ => bot.observeShowdown(Some(loss)))
+
+    assert(bot.decide(state) == Action.Fold)
+  }
+}
+


### PR DESCRIPTION
## Summary
- rebuild the bot betting policy from the mutable opponent model so it reflects current profile values
- refresh the policy before every decision and immediately after showdown adjustments
- add a focused BotSpec with a stubbed hand evaluator to ensure decisions change after model updates

## Testing
- sbt test *(fails: `sbt` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cff5f1b6f083258967397e2c0b5019